### PR TITLE
Drop carts and cart_items tables

### DIFF
--- a/db/migrate/20150810192132_drop_cart_table.rb
+++ b/db/migrate/20150810192132_drop_cart_table.rb
@@ -1,0 +1,6 @@
+class DropCartTable < ActiveRecord::Migration
+  def change
+    drop_table :carts
+    drop_table :cart_items
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,21 +11,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150808233215) do
+ActiveRecord::Schema.define(version: 20150810192132) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "cart_items", force: :cascade do |t|
-    t.integer "item_id"
-  end
-
-  add_index "cart_items", ["item_id"], name: "index_cart_items_on_item_id", using: :btree
-
-  create_table "carts", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
 
   create_table "categories", force: :cascade do |t|
     t.string   "name"
@@ -72,7 +61,6 @@ ActiveRecord::Schema.define(version: 20150808233215) do
     t.integer  "role",            default: 0
   end
 
-  add_foreign_key "cart_items", "items"
   add_foreign_key "order_items", "items"
   add_foreign_key "order_items", "orders"
   add_foreign_key "orders", "users"


### PR DESCRIPTION
These tables are not used anywhere in the application since the cart concept is entirely session-
based. Keeping Cart and CartItem models as those contain instructions for creating, persisting, and modifying the sessions.

closes #59 