### PR TITLE
remove phantom migration

### DIFF
--- a/db/migrate/20150810192132_drop_cart_table.rb
+++ b/db/migrate/20150810192132_drop_cart_table.rb
@@ -1,6 +1,0 @@
-class DropCartTable < ActiveRecord::Migration
-  def change
-    drop_table :carts
-    drop_table :cart_items
-  end
-end


### PR DESCRIPTION
we have a migration to drop a table that doesn't actually exist which is causing prod deploys to break
remove that migration file