### PR TITLE
Admin Can View all Orders

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,0 +1,5 @@
+class Admin::OrdersController < Admin::BaseController
+  def index
+    @orders = Order.all
+  end
+end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,16 +1,15 @@
 class OrdersController < ApplicationController
   def index
-    @orders = Order.all
+    @orders = current_user.orders
   end
 
   def show
-    @order = Order.find(params[:id])
+    @order = current_user.orders.find(params[:id])
   end
 
   def create
-    @order = Order.new()
-    @order.cart_data = session[:cart]
-    current_user.orders << @order
+    @order = current_user.orders.build
+    @order.cart_data = session[:cart] if session[:cart]
     if @order.save
       flash[:message] = "Order was successfully placed"
       session[:cart] = nil

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -18,8 +18,10 @@ class Order < ActiveRecord::Base
   private
 
   def create_from_cart
-    cart_data.each do |item_id, quantity|
-      OrderItem.create(quantity: quantity, item_id: item_id.to_i, order_id: id)
+    if cart_data
+      cart_data.each do |item_id, quantity|
+        OrderItem.create(quantity: quantity, item_id: item_id.to_i, order_id: id)
+      end
     end
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,7 +3,7 @@ class Order < ActiveRecord::Base
   has_many :order_items
   has_many :items, through: :order_items
 
-  before_save :create_from_cart
+  before_create :create_from_cart
 
   enum status: %w(ordered paid cancelled completed)
 
@@ -20,7 +20,7 @@ class Order < ActiveRecord::Base
   def create_from_cart
     if cart_data
       cart_data.each do |item_id, quantity|
-        OrderItem.create(quantity: quantity, item_id: item_id.to_i, order_id: id)
+        order_items.build(quantity: quantity, item_id: item_id.to_i, order_id: id)
       end
     end
   end

--- a/app/views/admin/admin/index.html.erb
+++ b/app/views/admin/admin/index.html.erb
@@ -1,6 +1,7 @@
 <div class="container">
-<h1>Admin Dashboard</h1>
+  <h1>Admin Dashboard</h1>
 
-<%= link_to "Create Item", new_admin_item_path %><br>
-<%= link_to "View all Items", admin_items_path %><br>
+  <%= link_to "Create Item", new_admin_item_path %><br>
+  <%= link_to "View all Items", admin_items_path %><br>
+  <%= link_to "View Orders", admin_orders_path %><br>
 </div>

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -16,4 +16,11 @@
 </table>
 <% end %>
 
+<h5>Order Status Summary</h5>
+<ul id="status_summary">
+  <% @orders.group_by { |order| order.status }.each do |status, orders| %>
+    <li><strong>Status:</strong> <%= status.capitalize %> <strong>Count:</strong> <%= orders.size %></li>
+  <% end %>
+</ul>
+
 </div>

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -1,0 +1,19 @@
+<div class="container" id="AdminOrdersPage">
+
+<h1>All Orders</h1>
+<% if @orders.size > 0 %>
+<table id="admin_orders">
+  <th>Customer ID</th>
+  <th>Order Status</th>
+  <th>Order Details</th>
+  <% @orders.each do |order| %>
+  <tr>
+    <td><%= order.user_id %></td>
+    <td><%= order.status %></td>
+    <td><%= link_to "View Order", order_path(order) %></td>
+  <% end %>
+  </tr>
+</table>
+<% end %>
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   namespace :admin do
     get "/dashboard", to: "admin#index"
     resources :items
+    resources :orders, only: [:index, :show]
   end
   resources :orders, only: [:index, :show, :create]
   get "/dashboard", to: "users#show"

--- a/spec/features/admin_can_see_all_orders_spec.rb
+++ b/spec/features/admin_can_see_all_orders_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.feature "AdminCanViewAllOrders", type: :feature do
+  let!(:user1) { User.create(username: "marla", password: "password", role: 0) }
+  let!(:user2) { User.create(username: "richard", password: "password", role: 0) }
+  let!(:admin) { User.create(username: "admin", password: "password", role: 1) }
+  let!(:item1) do
+    Item.create(title: "Parka",
+                description: "Stay warm in the tundra",
+                price: 3000,
+                image: "https://s-media-cache-ak0.pinimg.com/236x/90/eb/32/90eb32bc73e010067b15e08cac3ff016.jpg")
+  end
+  let!(:item2) do
+    Item.create(title: "specs",
+                description: "i see you",
+                price: 100,
+                image: "http://nobacks.com/wp-content/uploads/2014/11/Glasses-51-500x331.png")
+  end
+  let!(:order1) { Order.create(user_id: user1.id, status: 0) }
+  let!(:order2) { Order.create(user_id: user2.id, status: 0) }
+  let!(:order_item1) { OrderItem.create(quantity: 2, item_id: item1.id, order_id: order1.id) }
+  let!(:order_item2) { OrderItem.create(quantity: 3, item_id: item2.id, order_id: order1.id) }
+  let!(:order_item3) { OrderItem.create(quantity: 1, item_id: item1.id, order_id: order2.id) }
+  let!(:order_item4) { OrderItem.create(quantity: 1, item_id: item2.id, order_id: order2.id) }
+
+  context "logged in as an admin and viewing orders dashboard" do
+    before do
+      ApplicationController.any_instance.stubs(:current_user).returns(admin)
+    end
+
+    it "views all orders for all users" do
+      visit admin_dashboard_path
+      click_link "View Orders"
+
+      expect(current_path).to eq(admin_orders_path)
+      expect(page).to have_content("All Orders")
+      # within(".status") do
+      #   expect
+      expect(page).to have_link("View Order")
+    end
+  end
+end
+
+# When I visit the dashboard
+# Then I can see a listing of all orders
+# And I can see the total number of orders for each status ("Ordered", "Paid", "Cancelled", "Completed")
+# And I can see a link for each individual order
+# And I can filter orders to display by each status type  ("Ordered", "Paid", "Cancelled", "Completed")

--- a/spec/features/admin_can_see_all_orders_spec.rb
+++ b/spec/features/admin_can_see_all_orders_spec.rb
@@ -34,15 +34,11 @@ RSpec.feature "AdminCanViewAllOrders", type: :feature do
 
       expect(current_path).to eq(admin_orders_path)
       expect(page).to have_content("All Orders")
-      # within(".status") do
-      #   expect
+      expect(page).to have_content("Status")
       expect(page).to have_link("View Order")
+      within ("#status_summary") do
+        expect(page).to have_content("Status: Ordered Count: 2")
+      end
     end
   end
 end
-
-# When I visit the dashboard
-# Then I can see a listing of all orders
-# And I can see the total number of orders for each status ("Ordered", "Paid", "Cancelled", "Completed")
-# And I can see a link for each individual order
-# And I can filter orders to display by each status type  ("Ordered", "Paid", "Cancelled", "Completed")

--- a/spec/features/user_can_place_order_via_cart_spec.rb
+++ b/spec/features/user_can_place_order_via_cart_spec.rb
@@ -44,11 +44,3 @@ RSpec.feature "UserCanPlaceOrderViaCart", type: :feature do
     end
   end
 end
-
-# When I am logged in
-# And I visit "/cart"
-# And I click "Checkout"
-# Then the order should be placed
-# And my current page should be "/orders"
-# And I should see a message "Order was successfully placed"
-# And I should see the order I just placed in a table


### PR DESCRIPTION
Admin can view all orders across all users from an orders dashboard
Orders dashboard summarizes order statuses
Orders dashboard has link to view order details (not yet implemented)

Also fixes several bugs:

Ordering condition caused callback for order item creation to fail validation. Fixed ordering so that order item creation is not dependent on there already being an associated order in the database.

Orders were not being scoped to current_user when current_user was non-admin. This is now fixed as well.

Ready to merge.