### PR TITLE
fix admin order path

### DIFF
--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -10,7 +10,7 @@
   <tr>
     <td><%= order.user_id %></td>
     <td><%= order.status %></td>
-    <td><%= link_to "View Order", order_path(order) %></td>
+    <td><%= link_to "View Order", admin_order_path(order) %></td>
   <% end %>
   </tr>
 </table>


### PR DESCRIPTION
when admin clicks on order details from admin order dashboard, it should redirect to the admin order view